### PR TITLE
Helper scripts and tests for Intel K8s GPU device plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+*.snap

--- a/bin/gpu-plugin-validation
+++ b/bin/gpu-plugin-validation
@@ -1,0 +1,16 @@
+#!/usr/bin/env -S checkbox-cli-wrapper remote 127.0.0.1
+[launcher]
+app_id = com.canonical.qa.dss-validation:checkbox
+launcher_version = 1
+stock_reports = text, submission_files
+
+[test plan]
+unit = com.canonical.certification::gpu-plugin-validation
+forced = yes
+
+[test selection]
+forced = yes
+
+[ui]
+type = silent
+auto_retry = no

--- a/bin/install-dss-deps
+++ b/bin/install-dss-deps
@@ -1,0 +1,35 @@
+#!/bin/bash
+set -e
+
+echo -e "\nStep 1/3: Deploying MicroK8s snap"
+sudo snap install microk8s --classic --channel=1.29/stable
+
+USER=$(id -nu ${SNAP_UID})
+HOME=${SNAP_REAL_HOME}
+
+sudo usermod -a -G snap_microk8s $USER
+sudo usermod -a -G microk8s $USER
+sudo mkdir -p $HOME/.kube
+sudo mkdir -p $HOME/.local/share
+sudo chown -f -R $USER $HOME/.kube
+sudo chown -f -R $USER $HOME/.local/share
+
+echo -e "\nStep 2/3: Configuring MicroK8s addons"
+sudo microk8s enable dns
+sudo microk8s enable hostpath-storage
+sudo microk8s enable rbac
+
+echo "Waiting for microK8s addons to become ready..."
+sudo microk8s.kubectl wait \
+  --for=condition=available \
+  --timeout 1200s \
+  -n kube-system \
+  deployment/coredns \
+  deployment/hostpath-provisioner
+sudo microk8s.kubectl -n kube-system rollout status ds/calico-node
+
+# https://github.com/canonical/microk8s/issues/4453
+sudo snap install kubectl --classic --channel=1.29/stable
+# hack as redirecting stdout anywhere but /dev/null throws a permission denied error
+sudo microk8s kubectl config view --raw | tee $HOME/.kube/config > /dev/null
+

--- a/bin/install-dss-deps
+++ b/bin/install-dss-deps
@@ -7,7 +7,6 @@ sudo snap install microk8s --classic --channel=1.29/stable
 USER=$(id -nu ${SNAP_UID})
 HOME=${SNAP_REAL_HOME}
 
-sudo usermod -a -G snap_microk8s $USER
 sudo usermod -a -G microk8s $USER
 sudo mkdir -p $HOME/.kube
 sudo mkdir -p $HOME/.local/share

--- a/bin/remove-dss-deps
+++ b/bin/remove-dss-deps
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+USER=$(id -nu ${SNAP_UID})
+sudo snap remove microk8s --purge
+sudo snap remove kubectl --purge
+sudo deluser ${USER} snap_microk8s >& /dev/null
+sudo deluser ${USER} microk8s >& /dev/null

--- a/bin/remove-dss-deps
+++ b/bin/remove-dss-deps
@@ -3,5 +3,4 @@
 USER=$(id -nu ${SNAP_UID})
 sudo snap remove microk8s --purge
 sudo snap remove kubectl --purge
-sudo deluser ${USER} snap_microk8s >& /dev/null
-sudo deluser ${USER} microk8s >& /dev/null
+sudo delgroup microk8s

--- a/checkbox-provider-dss/units/jobs.pxu
+++ b/checkbox-provider-dss/units/jobs.pxu
@@ -37,6 +37,106 @@ template-resource: graphics_card
 template-filter: graphics_card.driver in ['i915']
 template-engine: jinja2
 template-unit: job
+id: intel_gpu_plugin/microk8s_install_intel_gpu_plugin_{{ driver }}
+category_id: opencl-regress
+flags: simple
+requires: executable.name == 'kubectl'
+_summary: Install Intel K8s GPU Device Plugin
+estimated_duration: 2m
+command:
+  # Using kubectl directly due to this bug: https://github.com/canonical/microk8s/issues/4453
+  kubectl apply -k 'https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/nfd?ref=v0.29.0'
+  kubectl apply -k 'https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/nfd/overlays/node-feature-rules?ref=v0.29.0'
+  kubectl apply -k 'https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/gpu_plugin/overlays/nfd_labeled_nodes?ref=v0.29.0'
+  sleep 5
+  kubectl -n node-feature-discovery rollout status ds/nfd-worker
+  kubectl -n default rollout status ds/intel-gpu-plugin
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.driver in ['i915']
+template-engine: jinja2
+template-unit: job
+id: intel_gpu_plugin/daemonset_check_name_{{ driver }}
+category_id: opencl-regress
+flags: simple
+requires: executable.name == 'microk8s'
+_summary: Check DaemonSet Name
+estimated_duration: 1s
+command:
+  result=$(microk8s.kubectl get daemonset.apps -o jsonpath='{.items[0].metadata.name}')
+  if [ "${result}" = "intel-gpu-plugin" ]; then
+      echo "Test success: 'intel-gpu-plugin' daemonset is deployed!"
+  else
+      echo "Test failure: expected daemonset name 'intel-gpu-plugin' but got ${result}"
+      exit 1
+  fi
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.driver in ['i915']
+template-engine: jinja2
+template-unit: job
+id: intel_gpu_plugin/daemonset_check_number_available_{{ driver }}
+category_id: opencl-regress
+flags: simple
+requires: executable.name == 'microk8s'
+_summary: Check number of available daemonsets
+estimated_duration: 1s
+command:
+  result=$(microk8s.kubectl get daemonset.apps -o jsonpath='{.items[0].status.numberAvailable}')
+  if [ "${result}" = "1" ]; then
+      echo "Test success: 1 daemonset in numberAvailable status."
+  else
+      echo "Test failure: expected numberAvailable to be 1 but got ${result}"
+      exit 1
+  fi
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.driver in ['i915']
+template-engine: jinja2
+template-unit: job
+id: intel_gpu_plugin/daemonset_check_number_ready_{{ driver }}
+category_id: opencl-regress
+flags: simple
+requires: executable.name == 'microk8s'
+_summary: Check number of ready daemonsets
+estimated_duration: 1s
+command:
+  result=$(microk8s.kubectl get daemonset.apps -o jsonpath='{.items[0].status.numberReady}')
+  if [ "${result}" = "1" ]; then
+      echo "Test success: 1 daemonset in numberReady status."
+  else
+      echo "Test failure: expected numberReady to be 1 but got ${result}"
+      exit 1
+  fi
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.driver in ['i915']
+template-engine: jinja2
+template-unit: job
+id: intel_gpu_plugin/cleanup_tests_{{ driver }}
+category_id: opencl-regress
+flags: simple
+user: root
+requires: executable.name == 'microk8s'
+_summary: Clean up after tests
+environ:
+  NORMAL_USER
+estimated_duration: 2m
+command:
+  for node in $(sudo microk8s kubectl get nodes -o name); do
+      microk8s.kubectl drain --ignore-daemonsets --delete-emptydir-data "${node}"
+  done
+  echo "Successfully cleaned up microk8s node(s)."
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.driver in ['i915']
+template-engine: jinja2
+template-unit: job
 id: itex/itex_deploy_{{ driver }}
 category_id: opencl-regress
 flags: simple

--- a/checkbox-provider-dss/units/test-plan.pxu
+++ b/checkbox-provider-dss/units/test-plan.pxu
@@ -1,3 +1,15 @@
+id: gpu-plugin-validation
+unit: test plan
+_name: Intel GPU k8s device plugin testing plan
+include:
+  intel_gpu_plugin/microk8s.*
+  intel_gpu_plugin/daemonset_check.*
+  intel_gpu_plugin/cleanup_tests.*
+bootstrap_include:
+    com.canonical.certification::executable
+    com.canonical.certification::snap
+    graphics_card
+
 id: ipex-validation
 unit: test plan
 _name: IPEX validation testing plan

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -44,6 +44,9 @@ apps:
   openvino-validation:
     command-chain: [bin/wrapper_local]
     command: bin/openvino-validation
+  gpu-plugin-validation:
+    command-chain: [bin/wrapper_local]
+    command: bin/gpu-plugin-validation
   remote-slave:
     command-chain: [bin/wrapper_local]
     command: bin/checkbox-cli-wrapper slave
@@ -54,6 +57,10 @@ apps:
     command: bin/shell-wrapper
   install-full-deps:
     command: bin/install-full-deps
+  install-dss-deps:
+    command: bin/install-dss-deps
+  remove-dss-deps:
+    command: bin/remove-dss-deps
 
 passthrough:
   hooks:


### PR DESCRIPTION
Still a bit rough but I think this is a decent starting place. Let me know what you think. I have the following running cleanly:

```
$ snapcraft
$ sudo snap install --dangerous --classic ./checkbox-dss_2.0_amd64.snap
$ checkbox-dss.install-dss-deps
$ checkbox-dss.gpu-plugin-validation
$ checkbox-dss.remove-dss-deps
``` 

Note that last command will remove the microk8s and kubectl snaps, which I don't love as a user could have these tools installed prior to testing. 