### PR TITLE
Add OpenVINO Installation and GPU Availability Test Cases

### DIFF
--- a/bin/install-dss-deps
+++ b/bin/install-dss-deps
@@ -32,3 +32,25 @@ sudo snap install kubectl --classic --channel=1.29/stable
 # hack as redirecting stdout anywhere but /dev/null throws a permission denied error
 # see: https://forum.snapcraft.io/t/eksctl-cannot-write-to-stdout/17254/4
 sudo microk8s.kubectl config view --raw | tee $HOME/.kube/config > /dev/null
+
+echo -e "\nStep 3/3: Installing Docker"
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install ca-certificates curl
+sudo install -m 0755 -d /etc/apt/keyrings
+sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+sudo chmod a+r /etc/apt/keyrings/docker.asc
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo groupadd -f docker
+sudo usermod -aG docker $USER
+
+# Clone DSS repo for K8s manifest files
+git clone https://github.com/canonical/data-science-stack /tmp/data-science-stack

--- a/bin/install-dss-deps
+++ b/bin/install-dss-deps
@@ -30,5 +30,5 @@ sudo microk8s.kubectl -n kube-system rollout status ds/calico-node
 # https://github.com/canonical/microk8s/issues/4453
 sudo snap install kubectl --classic --channel=1.29/stable
 # hack as redirecting stdout anywhere but /dev/null throws a permission denied error
-sudo microk8s kubectl config view --raw | tee $HOME/.kube/config > /dev/null
-
+# see: https://forum.snapcraft.io/t/eksctl-cannot-write-to-stdout/17254/4
+sudo microk8s.kubectl config view --raw | tee $HOME/.kube/config > /dev/null

--- a/bin/install-full-deps
+++ b/bin/install-full-deps
@@ -50,22 +50,4 @@ cd build && cmake ..
 cmake --build .
 cmake --build . --target install
 
-git clone https://github.com/canonical/data-science-stack /tmp/data-science-stack
-
-# Add Docker's official GPG key:
-sudo apt-get update
-sudo apt-get install ca-certificates curl
-sudo install -m 0755 -d /etc/apt/keyrings
-sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-sudo chmod a+r /etc/apt/keyrings/docker.asc
-
-# Add the repository to Apt sources:
-echo \
-  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-sudo apt-get update
-
-sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
-
 exit 0

--- a/bin/remove-dss-deps
+++ b/bin/remove-dss-deps
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-USER=$(id -nu ${SNAP_UID})
+for node in $(sudo microk8s.kubectl get nodes -o name); do
+    microk8s.kubectl drain --ignore-daemonsets --delete-emptydir-data "${node}"
+done
 sudo snap remove microk8s --purge
 sudo snap remove kubectl --purge
 sudo delgroup microk8s

--- a/bin/remove-dss-deps
+++ b/bin/remove-dss-deps
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 for node in $(sudo microk8s.kubectl get nodes -o name); do
-    microk8s.kubectl drain --ignore-daemonsets --delete-emptydir-data "${node}"
+    sudo microk8s.kubectl drain --ignore-daemonsets --delete-emptydir-data "${node}"
 done
 sudo snap remove microk8s --purge
 sudo snap remove kubectl --purge

--- a/checkbox-provider-dss/units/jobs.pxu
+++ b/checkbox-provider-dss/units/jobs.pxu
@@ -54,6 +54,9 @@ command:
   sleep 5
   kubectl -n node-feature-discovery rollout status ds/nfd-worker
   kubectl -n default rollout status ds/intel-gpu-plugin
+  SLEEP_SECS=15
+  echo "Info: sleeping for ${SLEEP_SECS} to allow pod status to update for subsequent tests."
+  sleep ${SLEEP_SECS}
   echo "Test success: Intel K8s GPU Device Plugin deployed."
 
 unit: template
@@ -73,7 +76,7 @@ command:
   if [ "${result}" = "intel-gpu-plugin" ]; then
       echo "Test success: 'intel-gpu-plugin' daemonset is deployed!"
   else
-      echo "Test failure: expected daemonset name 'intel-gpu-plugin' but got ${result}"
+      >&2 echo "Test failure: expected daemonset name 'intel-gpu-plugin' but got ${result}"
       exit 1
   fi
 
@@ -90,11 +93,24 @@ _summary: Check number of available daemonsets
 estimated_duration: 1s
 command:
   set -e
+  SLEEP_SECS=10
+  RETRIES=10
   result=$(microk8s.kubectl get daemonset.apps -o jsonpath='{.items[0].status.numberAvailable}')
+  retry_cnt=0
+  while [ -z "${result}" ]; do
+      if [ "${retry_cnt}" = "10" ]; then
+          >&2 echo "Test failure: empty numberAvailable result after ${retry_cnt} retries."
+          exit 1
+      fi
+      retry_cnt=$((retry_cnt+1))
+      echo "Info: received empty numberAvailable result. Sleeping for ${SLEEP_SECS} seconds. Retry $retry_cnt/$RETRIES."
+      sleep ${SLEEP_SECS}
+      result=$(microk8s.kubectl get daemonset.apps -o jsonpath='{.items[0].status.numberAvailable}')
+  done
   if [ "${result}" = "1" ]; then
       echo "Test success: 1 daemonset in numberAvailable status."
   else
-      echo "Test failure: expected numberAvailable to be 1 but got ${result}"
+      >&2 echo "Test failure: expected numberAvailable to be 1 but got ${result}"
       exit 1
   fi
 
@@ -111,11 +127,24 @@ _summary: Check number of ready daemonsets
 estimated_duration: 1s
 command:
   set -e
+  SLEEP_SECS=10
+  RETRIES=10
   result=$(microk8s.kubectl get daemonset.apps -o jsonpath='{.items[0].status.numberReady}')
+  retry_cnt=0
+  while [ -z "${result}" ]; do
+      if [ "${retry_cnt}" = "10" ]; then
+          >&2 echo "Test failure: empty numberReady result after ${retry_cnt} retries."
+          exit 1
+      fi
+      retry_cnt=$((retry_cnt+1))
+      echo "Info: received empty numberReady result. Sleeping for ${SLEEP_SECS} seconds. Retry $retry_cnt/$RETRIES."
+      sleep ${SLEEP_SECS}
+      result=$(microk8s.kubectl get daemonset.apps -o jsonpath='{.items[0].status.numberReady}')
+  done
   if [ "${result}" = "1" ]; then
       echo "Test success: 1 daemonset in numberReady status."
   else
-      echo "Test failure: expected numberReady to be 1 but got ${result}"
+      >&2 echo "Test failure: expected numberReady to be 1 but got ${result}"
       exit 1
   fi
 
@@ -158,7 +187,7 @@ command:
   if [ "${result}" = "mlflow" ]; then
       echo "Test success: 'mlflow' service is deployed!"
   else
-      echo "Test failure: expected service name 'mlflow' but got ${result}"
+      >&2 echo "Test failure: expected service name 'mlflow' but got ${result}"
       exit 1
   fi
 
@@ -216,7 +245,7 @@ command:
   if grep -qw "notebook-openvino" <<<${all_apps}; then
       echo "Test success: 'notebook-openvino' app is deployed!"
   else
-      echo "Test failure: expected result to contain app name 'notebook-openvino' but got ${result}"
+      >&2 echo "Test failure: expected result to contain app name 'notebook-openvino' but got ${result}"
       exit 1
   fi
 

--- a/checkbox-provider-dss/units/jobs.pxu
+++ b/checkbox-provider-dss/units/jobs.pxu
@@ -32,6 +32,8 @@ command:
       fi
   done
 
+# TODO: add host-level Intel GPU checks (lspci, ls /dev/dri)
+
 unit: template
 template-resource: graphics_card
 template-filter: graphics_card.driver in ['i915']
@@ -51,6 +53,7 @@ command:
   sleep 5
   kubectl -n node-feature-discovery rollout status ds/nfd-worker
   kubectl -n default rollout status ds/intel-gpu-plugin
+  echo "Test success: Intel K8s GPU Device Plugin deployed."
 
 unit: template
 template-resource: graphics_card
@@ -112,25 +115,151 @@ command:
       exit 1
   fi
 
+# TODO: add node label checks
+
 unit: template
 template-resource: graphics_card
 template-filter: graphics_card.driver in ['i915']
 template-engine: jinja2
 template-unit: job
-id: intel_gpu_plugin/cleanup_tests_{{ driver }}
+id: intel_gpu_plugin/dss_initialize_{{ driver }}
 category_id: opencl-regress
 flags: simple
-user: root
 requires: executable.name == 'microk8s'
-_summary: Clean up after tests
-environ:
-  NORMAL_USER
+_summary: Initialize DSS environment with common k8s manifests
 estimated_duration: 2m
 command:
-  for node in $(sudo microk8s kubectl get nodes -o name); do
-      microk8s.kubectl drain --ignore-daemonsets --delete-emptydir-data "${node}"
-  done
-  echo "Successfully cleaned up microk8s node(s)."
+  DSS_COMMON_MANIFESTS=/tmp/data-science-stack/poc/common-manifests
+  sudo microk8s.kubectl apply -f ${DSS_COMMON_MANIFESTS}/namespace.yaml
+  sudo microk8s.kubectl apply -f ${DSS_COMMON_MANIFESTS}/mlflow.yaml
+  sudo microk8s.kubectl apply -f ${DSS_COMMON_MANIFESTS}/notebooks.yaml
+  sudo microk8s.kubectl wait --for condition=available --timeout 1200s -n dss deployment -l app=dss-mlflow
+  echo "Test success: common DSS manifests deployed."
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.driver in ['i915']
+template-engine: jinja2
+template-unit: job
+id: intel_gpu_plugin/dss_check_service_name{{ driver }}
+category_id: opencl-regress
+flags: simple
+requires: executable.name == 'microk8s'
+_summary: Check Service Name
+estimated_duration: 1s
+command:
+  result=$(microk8s.kubectl get service -n dss -o jsonpath='{.items[0].metadata.name}')
+  if [ "${result}" = "mlflow" ]; then
+      echo "Test success: 'mlflow' service is deployed!"
+  else
+      echo "Test failure: expected service name 'mlflow' but got ${result}"
+      exit 1
+  fi
+
+# TODO: check other service and deployment details
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.driver in ['i915']
+template-engine: jinja2
+template-unit: job
+id: intel_gpu_plugin/openvino_start_{{ driver }}
+category_id: opencl-regress
+flags: simple
+requires:
+  executable.name == 'docker'
+  executable.name == 'microk8s'
+_summary: Launch OpenVINO+Jupyter container
+estimated_duration: 6m
+command:
+  set -e
+  DSS_INTEL_POC_ROOT=/tmp/data-science-stack/poc/intel
+  OPENVINO_IMAGE="local/openvinotoolkit:render-addon"
+  OPENVINO_TAR_IMAGE="/tmp/openvino.tar"
+  echo "Building OpenVINO Docker image locally. Please be patient."
+  docker build -q -t local/openvinotoolkit:mainbranch github.com/openvinotoolkit/openvino_notebooks
+  render_gid=$(getent group render | cut -d: -f3)
+  container_user=$(docker run --rm local/openvinotoolkit:mainbranch /usr/bin/whoami)
+  cat ${DSS_INTEL_POC_ROOT}/openvino-image/Dockerfile | docker build -q \
+    -t local/openvinotoolkit:render-addon \
+    --build-arg render_gid=${render_gid} \
+    --build-arg container_user=${container_user} -
+  # hack as redirecting stdout anywhere but /dev/null throws a permission denied error
+  # see: https://forum.snapcraft.io/t/eksctl-cannot-write-to-stdout/17254/4
+  docker save local/openvinotoolkit:render-addon | tee ${OPENVINO_TAR_IMAGE} > /dev/null
+  microk8s ctr image import ${OPENVINO_TAR_IMAGE}
+  rm -f ${OPENVINO_TAR_IMAGE}
+  sudo microk8s kubectl apply -f ${DSS_INTEL_POC_ROOT}/manifests/notebook-openvino.yaml
+  sudo microk8s.kubectl wait --for condition=available --timeout 1200s -n dss deployment -l app=user-notebook-openvino
+  echo "Test success: OpenVINO+Jupyter container is running."
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.driver in ['i915']
+template-engine: jinja2
+template-unit: job
+id: intel_gpu_plugin/openvino_deployment_{{ driver }}
+category_id: opencl-regress
+flags: simple
+requires: executable.name == 'microk8s'
+_summary: Check OpenVINO Deployment
+estimated_duration: 1s
+command:
+  all_apps=$(microk8s.kubectl get deployment.apps -n dss -o jsonpath='{.items..metadata.name}')
+  if grep -qw "notebook-openvino" <<<${all_apps}; then
+      echo "Test success: 'notebook-openvino' app is deployed!"
+  else
+      echo "Test failure: expected result to contain app name 'notebook-openvino' but got ${result}"
+      exit 1
+  fi
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.driver in ['i915']
+template-engine: jinja2
+template-unit: job
+id: intel_gpu_plugin/openvino_libs_installed_{{ driver }}
+category_id: opencl-regress
+flags: simple
+requires: executable.name == 'microk8s'
+_summary: Check jupyter and openvino python packages in OpenVINO container
+estimated_duration: 1s
+command:
+  set -e
+  pod=$(microk8s.kubectl get pods -n dss -o=jsonpath='{.items..metadata.name}' | grep -o 'notebook-openvino.*')
+  echo "Examining pod ${pod}..."
+  microk8s.kubectl -n dss exec ${pod} -- pip show jupyter
+  microk8s.kubectl -n dss exec ${pod} -- pip show openvino
+  echo "Test success: jupyter and openvino python packages installed in container."
+
+unit: template
+template-resource: graphics_card
+template-filter: graphics_card.driver in ['i915']
+template-engine: jinja2
+template-unit: job
+id: intel_gpu_plugin/openvino_gpu_avail_{{ driver }}
+category_id: opencl-regress
+flags: simple
+requires: executable.name == 'microk8s'
+_summary: Check OpenVINO GPU Availability
+estimated_duration: 1s
+command:
+  set -e
+  pod=$(microk8s.kubectl get pods -n dss -o=jsonpath='{.items..metadata.name}' | grep -o 'notebook-openvino.*')
+  echo "Examining pod ${pod}..."
+  microk8s kubectl -n dss exec -i --tty=false ${pod} -- python3 \
+  <<EOF
+  import sys
+  import openvino as ov
+  core = ov.Core()
+  if "GPU" in core.available_devices:
+    full_device_name = core.get_property("GPU", "FULL_DEVICE_NAME")
+    print(f"Test success: Intel GPU device ({full_device_name}) available to OpenVINO.")
+    sys.exit(0)
+  else:
+    print("Test failure: No Intel GPU device available to OpenVINO.", file=sys.stderr)
+    sys.exit(1)
+  EOF
 
 unit: template
 template-resource: graphics_card

--- a/checkbox-provider-dss/units/jobs.pxu
+++ b/checkbox-provider-dss/units/jobs.pxu
@@ -46,6 +46,7 @@ requires: executable.name == 'kubectl'
 _summary: Install Intel K8s GPU Device Plugin
 estimated_duration: 2m
 command:
+  set -e
   # Using kubectl directly due to this bug: https://github.com/canonical/microk8s/issues/4453
   kubectl apply -k 'https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/nfd?ref=v0.29.0'
   kubectl apply -k 'https://github.com/intel/intel-device-plugins-for-kubernetes/deployments/nfd/overlays/node-feature-rules?ref=v0.29.0'
@@ -67,6 +68,7 @@ requires: executable.name == 'microk8s'
 _summary: Check DaemonSet Name
 estimated_duration: 1s
 command:
+  set -e
   result=$(microk8s.kubectl get daemonset.apps -o jsonpath='{.items[0].metadata.name}')
   if [ "${result}" = "intel-gpu-plugin" ]; then
       echo "Test success: 'intel-gpu-plugin' daemonset is deployed!"
@@ -87,6 +89,7 @@ requires: executable.name == 'microk8s'
 _summary: Check number of available daemonsets
 estimated_duration: 1s
 command:
+  set -e
   result=$(microk8s.kubectl get daemonset.apps -o jsonpath='{.items[0].status.numberAvailable}')
   if [ "${result}" = "1" ]; then
       echo "Test success: 1 daemonset in numberAvailable status."
@@ -107,6 +110,7 @@ requires: executable.name == 'microk8s'
 _summary: Check number of ready daemonsets
 estimated_duration: 1s
 command:
+  set -e
   result=$(microk8s.kubectl get daemonset.apps -o jsonpath='{.items[0].status.numberReady}')
   if [ "${result}" = "1" ]; then
       echo "Test success: 1 daemonset in numberReady status."
@@ -129,6 +133,7 @@ requires: executable.name == 'microk8s'
 _summary: Initialize DSS environment with common k8s manifests
 estimated_duration: 2m
 command:
+  set -e
   DSS_COMMON_MANIFESTS=/tmp/data-science-stack/poc/common-manifests
   sudo microk8s.kubectl apply -f ${DSS_COMMON_MANIFESTS}/namespace.yaml
   sudo microk8s.kubectl apply -f ${DSS_COMMON_MANIFESTS}/mlflow.yaml
@@ -141,13 +146,14 @@ template-resource: graphics_card
 template-filter: graphics_card.driver in ['i915']
 template-engine: jinja2
 template-unit: job
-id: intel_gpu_plugin/dss_check_service_name{{ driver }}
+id: intel_gpu_plugin/dss_check_service_name_{{ driver }}
 category_id: opencl-regress
 flags: simple
 requires: executable.name == 'microk8s'
 _summary: Check Service Name
 estimated_duration: 1s
 command:
+  set -e
   result=$(microk8s.kubectl get service -n dss -o jsonpath='{.items[0].metadata.name}')
   if [ "${result}" = "mlflow" ]; then
       echo "Test success: 'mlflow' service is deployed!"
@@ -205,6 +211,7 @@ requires: executable.name == 'microk8s'
 _summary: Check OpenVINO Deployment
 estimated_duration: 1s
 command:
+  set -e
   all_apps=$(microk8s.kubectl get deployment.apps -n dss -o jsonpath='{.items..metadata.name}')
   if grep -qw "notebook-openvino" <<<${all_apps}; then
       echo "Test success: 'notebook-openvino' app is deployed!"

--- a/checkbox-provider-dss/units/test-plan.pxu
+++ b/checkbox-provider-dss/units/test-plan.pxu
@@ -4,7 +4,8 @@ _name: Intel GPU k8s device plugin testing plan
 include:
   intel_gpu_plugin/microk8s.*
   intel_gpu_plugin/daemonset_check.*
-  intel_gpu_plugin/cleanup_tests.*
+  intel_gpu_plugin/dss_.*
+  intel_gpu_plugin/openvino_.*
 bootstrap_include:
     com.canonical.certification::executable
     com.canonical.certification::snap


### PR DESCRIPTION
This uses the same flow as before for getting the environment all set up:

```
$ snapcraft
$ sudo snap install --dangerous --classic ./checkbox-dss_2.0_amd64.snap
$ checkbox-dss.install-dss-deps
$ checkbox-dss.install-full-deps # for docker
$ checkbox-dss.gpu-plugin-validation
$ checkbox-dss.remove-dss-deps
```

For the GPU availability test, I took [the code from this notebook](https://github.com/openvinotoolkit/openvino_notebooks/blob/main/notebooks/108-gpu-device/108-gpu-device.ipynb) in the Intel OpenVINO Toolkit GitHub repo.
