### PR TITLE
Add dss stable channel to regression tests

### DIFF
--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -14,6 +14,11 @@ jobs:
   regression-tests-A:
     name: Regression tests on Testflinger instance A
     runs-on: [testflinger]
+    strategy:
+      matrix:
+        dss_channel:
+          - latest/stable
+          - latest/edge
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -22,7 +27,7 @@ jobs:
           BRANCH: ${{ github.head_ref || github.ref_name }}
           QUEUE: dell-precision-3470-c30322 #ADL iGPU + NVIDIA GPU
           PROVISION_DATA: "distro: jammy"
-          DSS_CHANNEL: "latest/edge"
+          DSS_CHANNEL: ${{ matrix.dss_channel }}
         run: |
           sed -e "s|REPLACE_BRANCH|${BRANCH}|" \
           -e "s|REPLACE_QUEUE|${QUEUE}|" \
@@ -39,6 +44,11 @@ jobs:
   regression-tests-B:
     name: Regression tests on Testflinger instance B
     runs-on: [testflinger]
+    strategy:
+      matrix:
+        dss_channel:
+          - latest/stable
+          - latest/edge
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -47,7 +57,7 @@ jobs:
           BRANCH: ${{ github.head_ref || github.ref_name }}
           QUEUE: dell-precision-5680-c31665 #RPL iGPU + Arc Pro A60M dGPU
           PROVISION_DATA: "url: http://10.102.196.9/somerville/Platforms/jellyfish-muk/X96_A00/dell-bto-jammy-jellyfish-muk-X96-20230419-19_A00.iso"
-          DSS_CHANNEL: "latest/edge"
+          DSS_CHANNEL: ${{ matrix.dss_channel }}
         run: |
           sed -e "s|REPLACE_BRANCH|${BRANCH}|" \
           -e "s|REPLACE_QUEUE|${QUEUE}|" \

--- a/.github/workflows/regression.yaml
+++ b/.github/workflows/regression.yaml
@@ -10,63 +10,48 @@ on:
     branches:
       - main
 
-jobs:
-  regression-tests-A:
-    name: Regression tests on Testflinger instance A
-    runs-on: [testflinger]
-    strategy:
-      matrix:
-        dss_channel:
-          - latest/stable
-          - latest/edge
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v4
-      - name: Build job file from template
-        env:
-          BRANCH: ${{ github.head_ref || github.ref_name }}
-          QUEUE: dell-precision-3470-c30322 #ADL iGPU + NVIDIA GPU
-          PROVISION_DATA: "distro: jammy"
-          DSS_CHANNEL: ${{ matrix.dss_channel }}
-        run: |
-          sed -e "s|REPLACE_BRANCH|${BRANCH}|" \
-          -e "s|REPLACE_QUEUE|${QUEUE}|" \
-          -e "s|REPLACE_PROVISION_DATA|${PROVISION_DATA}|" \
-          -e "s|REPLACE_DSS_CHANNEL|${DSS_CHANNEL}|" \
-          ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
-          ${GITHUB_WORKSPACE}/maas2.yaml
-      - name: Submit testflinger job
-        uses: canonical/testflinger/.github/actions/submit@main
-        with:
-          poll: true
-          job-path: ${GITHUB_WORKSPACE}/maas2.yaml
+env:
+  BRANCH: ${{ github.head_ref || github.ref_name }}
 
-  regression-tests-B:
-    name: Regression tests on Testflinger instance B
+jobs:
+  regression-tests:
+    name: Regression tests
     runs-on: [testflinger]
     strategy:
       matrix:
         dss_channel:
           - latest/stable
           - latest/edge
+        queue:
+          - dell-precision-3470-c30322 #ADL iGPU + NVIDIA GPU
+          - dell-precision-5680-c31665 #RPL iGPU + Arc Pro A60M dGPU
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Build job file from template
+      - name: Build job file from template with maas2 provisioning
+        if: ${{ matrix.queue == 'dell-precision-3470-c30322' }}
         env:
-          BRANCH: ${{ github.head_ref || github.ref_name }}
-          QUEUE: dell-precision-5680-c31665 #RPL iGPU + Arc Pro A60M dGPU
-          PROVISION_DATA: "url: http://10.102.196.9/somerville/Platforms/jellyfish-muk/X96_A00/dell-bto-jammy-jellyfish-muk-X96-20230419-19_A00.iso"
-          DSS_CHANNEL: ${{ matrix.dss_channel }}
+          PROVISION_DATA: "distro: jammy"
         run: |
           sed -e "s|REPLACE_BRANCH|${BRANCH}|" \
-          -e "s|REPLACE_QUEUE|${QUEUE}|" \
+          -e "s|REPLACE_QUEUE|${{ matrix.queue }}|" \
           -e "s|REPLACE_PROVISION_DATA|${PROVISION_DATA}|" \
-          -e "s|REPLACE_DSS_CHANNEL|${DSS_CHANNEL}|" \
+          -e "s|REPLACE_DSS_CHANNEL|${{ matrix.dss_channel }}|" \
           ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
-          ${GITHUB_WORKSPACE}/oemscript.yaml
+          ${GITHUB_WORKSPACE}/job.yaml
+      - name: Build job file from template with oemscript provisioning
+        if: ${{ matrix.queue == 'dell-precision-5680-c31665' }}
+        env:
+          PROVISION_DATA: "url: http://10.102.196.9/somerville/Platforms/jellyfish-muk/X96_A00/dell-bto-jammy-jellyfish-muk-X96-20230419-19_A00.iso"
+        run: |
+          sed -e "s|REPLACE_BRANCH|${BRANCH}|" \
+          -e "s|REPLACE_QUEUE|${{ matrix.queue }}|" \
+          -e "s|REPLACE_PROVISION_DATA|${PROVISION_DATA}|" \
+          -e "s|REPLACE_DSS_CHANNEL|${{ matrix.dss_channel }}|" \
+          ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
+          ${GITHUB_WORKSPACE}/job.yaml
       - name: Submit testflinger job
         uses: canonical/testflinger/.github/actions/submit@main
         with:
           poll: true
-          job-path: ${GITHUB_WORKSPACE}/oemscript.yaml
+          job-path: ${GITHUB_WORKSPACE}/job.yaml


### PR DESCRIPTION
Intel GPU support in DSS was promoted from `latest/edge` to `latest/stable`, so this adds `latest/stable` to the regression tests. 